### PR TITLE
Added support to ClusterFlows

### DIFF
--- a/operator/api/v1alpha1/flowtest_types.go
+++ b/operator/api/v1alpha1/flowtest_types.go
@@ -35,6 +35,8 @@ type FlowTestStatus struct {
 	// +nullable
 	FailedMatches []flowv1beta1.Match `json:"failedMatches"`
 	// +nullable
+	FailedClusterMatches []flowv1beta1.ClusterMatch `json:"failedClusterMatches"`
+	// +nullable
 	FailedFilters []flowv1beta1.Filter `json:"failedFilters"`
 	// +kubebuilder:default:="Created"
 	// +kubebuilder:validation:Enum=Created;Running;Completed;Error

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -116,6 +116,13 @@ func (in *FlowTestStatus) DeepCopyInto(out *FlowTestStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.FailedClusterMatches != nil {
+		in, out := &in.FailedClusterMatches, &out.FailedClusterMatches
+		*out = make([]v1beta1.ClusterMatch, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.FailedFilters != nil {
 		in, out := &in.FailedFilters, &out.FailedFilters
 		*out = make([]v1beta1.Filter, len(*in))

--- a/operator/config/crd/bases/loggingplumber.isala.me_flowtests.yaml
+++ b/operator/config/crd/bases/loggingplumber.isala.me_flowtests.yaml
@@ -84,6 +84,50 @@ spec:
           status:
             description: FlowTestStatus defines the observed state of FlowTest
             properties:
+              failedClusterMatches:
+                items:
+                  properties:
+                    exclude:
+                      properties:
+                        container_names:
+                          items:
+                            type: string
+                          type: array
+                        hosts:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        namespaces:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    select:
+                      properties:
+                        container_names:
+                          items:
+                            type: string
+                          type: array
+                        hosts:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        namespaces:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                nullable: true
+                type: array
               failedFilters:
                 items:
                   description: Filter definition for FlowSpec
@@ -1198,6 +1242,7 @@ spec:
                 - Error
                 type: string
             required:
+            - failedClusterMatches
             - failedFilters
             - failedMatches
             - status

--- a/operator/config/samples/loggingplumber_v1alpha1_flowtest.yaml
+++ b/operator/config/samples/loggingplumber_v1alpha1_flowtest.yaml
@@ -21,3 +21,27 @@ spec:
     - "[2021-06-10T11:50:07Z] @WARNING Ne hi flagitantur alienam neglecta. 1374 ::0.474177"
     - "[2021-06-10T11:50:08Z] @INFO Amo ideoque die se at, caro aer, ad cor. 1375 ::0.263548"
     - "[2021-06-10T11:50:09Z] @INFO Se contexo servis inpiis erogo, diligit ita significaret eosdem. 1376 ::0.405282"
+---
+apiVersion: loggingplumber.isala.me/v1alpha1
+kind: FlowTest
+metadata:
+  name: clusterflowtest-sample
+  labels:
+    app.kubernetes.io/name: pod-simulation
+    app.kubernetes.io/managed-by: rancher-logging-explorer
+    app.kubernetes.io/created-by: logging-plumber
+    loggingplumber.isala.me/flowtest: clusterflowtest-sample
+spec:
+  referencePod:
+    kind: Pod
+    name: busybox-echo
+    namespace: default
+  referenceFlow:
+    kind: ClusterFlow
+    name: cluster-busybox-echo
+    namespace: "cattle-logging-system"
+  sentMessages:
+    - "[2021-06-10T11:50:06Z] @DEBUG Tam ipsae consuetudo infelix adtendi contexo mansuefecisti diutius re. 1373 ::0.403911"
+    - "[2021-06-10T11:50:07Z] @WARNING Ne hi flagitantur alienam neglecta. 1374 ::0.474177"
+    - "[2021-06-10T11:50:08Z] @INFO Amo ideoque die se at, caro aer, ad cor. 1375 ::0.263548"
+    - "[2021-06-10T11:50:09Z] @INFO Se contexo servis inpiis erogo, diligit ita significaret eosdem. 1376 ::0.405282"

--- a/operator/config/samples/simulations.yaml
+++ b/operator/config/samples/simulations.yaml
@@ -1,15 +1,3 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: busybox-echo
-  labels:
-    loggingplumber.isala.me/test: simulations
-spec:
-  containers:
-    - name: busybox
-      image: busybox
-      command: ["sh", "-c", "x=1; while [ $x -gt -1 ]; do echo \"{'count': '$(( x++ ))', 'date': '$(date)'}\" && sleep 5; done"]
----
 apiVersion: logging.banzaicloud.io/v1beta1
 kind: Flow
 metadata:
@@ -48,6 +36,46 @@ spec:
       flush_interval: 10s
       flush_mode: interval
 ---
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: ClusterFlow
+metadata:
+  name: cluster-busybox-echo
+  namespace: cattle-logging-system
+  labels:
+    loggingplumber.isala.me/test: simulations
+spec:
+  globalOutputRefs:
+    - cluster-busybox-echo
+  match:
+    - select:
+        labels:
+          loggingplumber.isala.me/test: invalid
+    - select:
+        labels:
+          loggingplumber.isala.me/test: simulations
+  filters:
+    - record_modifier:
+        records:
+          - foo: "bar"
+    - grep:
+        regexp:
+          - key: first
+            pattern: /^5\d\d$/
+---
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: ClusterOutput
+metadata:
+  name: cluster-busybox-echo
+  namespace: cattle-logging-system
+  labels:
+    loggingplumber.isala.me/test: simulations
+spec:
+  http:
+    endpoint: "http://logging-plumber-log-aggregator.default.svc/cluster-busybox-echo/"
+    buffer:
+      flush_interval: 10s
+      flush_mode: interval
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -66,3 +94,15 @@ spec:
     app.kubernetes.io/managed-by: rancher-logging-explorer
     app.kubernetes.io/created-by: logging-plumber
     loggingplumber.isala.me/component: log-aggregator
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox-echo
+  labels:
+    loggingplumber.isala.me/test: simulations
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      command: ["sh", "-c", "x=1; while [ $x -gt -1 ]; do echo \"{'count': '$(( x++ ))', 'date': '$(date)'}\" && sleep 5; done"]

--- a/operator/controllers/cleanup.go
+++ b/operator/controllers/cleanup.go
@@ -70,5 +70,33 @@ func (r *FlowTestReconciler) cleanUpResources(ctx context.Context, flowTestName 
 		logger.V(1).Info(fmt.Sprintf("%s deleted", resource.Kind), "uuid", resource.GetUID(), "name", resource.GetName())
 	}
 
+	var clusterFlows flowv1beta1.ClusterFlowList
+	if err := r.List(ctx, &clusterFlows, &client.MatchingLabels{"loggingplumber.isala.me/flowtest": flowTestName}); client.IgnoreNotFound(err) != nil {
+		logger.Error(err, fmt.Sprintf("failed to get provisioned %s", clusterFlows.Kind))
+		//return err
+	}
+
+	for _, resource := range clusterFlows.Items {
+		if err := r.Delete(ctx, &resource); client.IgnoreNotFound(err) != nil {
+			logger.Error(err, fmt.Sprintf("failed to delete a provisioned %s", resource.Kind), "uuid", resource.GetUID(), "name", resource.GetName())
+			return err
+		}
+		logger.V(1).Info(fmt.Sprintf("%s deleted", resource.Kind), "uuid", resource.GetUID(), "name", resource.GetName())
+	}
+
+	var clusterOutputs flowv1beta1.ClusterOutputList
+	if err := r.List(ctx, &clusterOutputs, &client.MatchingLabels{"loggingplumber.isala.me/flowtest": flowTestName}); client.IgnoreNotFound(err) != nil {
+		logger.Error(err, fmt.Sprintf("failed to get provisioned %s", clusterOutputs.Kind))
+		//return err
+	}
+
+	for _, resource := range clusterOutputs.Items {
+		if err := r.Delete(ctx, &resource); client.IgnoreNotFound(err) != nil {
+			logger.Error(err, fmt.Sprintf("failed to delete a provisioned %s", resource.Kind), "uuid", resource.GetUID(), "name", resource.GetName())
+			return err
+		}
+		logger.V(1).Info(fmt.Sprintf("%s deleted", resource.Kind), "uuid", resource.GetUID(), "name", resource.GetName())
+	}
+
 	return nil
 }

--- a/operator/controllers/utils.go
+++ b/operator/controllers/utils.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func banzaiTemplates(flow flowv1beta1.Flow, flowTest loggingplumberv1alpha1.FlowTest, extraLabels map[string]string) (flowv1beta1.Flow, flowv1beta1.Output) {
+func flowTemplates(flow flowv1beta1.Flow, flowTest loggingplumberv1alpha1.FlowTest, extraLabels map[string]string) (flowv1beta1.Flow, flowv1beta1.Output) {
 	flowTemplate := flowv1beta1.Flow{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "logging.banzaicloud.io/v1beta1",
@@ -60,6 +60,63 @@ func banzaiTemplates(flow flowv1beta1.Flow, flowTest loggingplumberv1alpha1.Flow
 				Buffer: &output.Buffer{
 					FlushMode:     "interval",
 					FlushInterval: "10s",
+				},
+			},
+		},
+	}
+
+	return flowTemplate, outTemplate
+}
+
+func clusterFlowTemplates(flow flowv1beta1.ClusterFlow, flowTest loggingplumberv1alpha1.FlowTest, extraLabels map[string]string) (flowv1beta1.ClusterFlow, flowv1beta1.ClusterOutput) {
+	flowTemplate := flowv1beta1.ClusterFlow{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "logging.banzaicloud.io/v1beta1",
+			Kind:       "ClusterFlow",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-test", flow.ObjectMeta.Name),
+			Namespace: flowTest.Spec.ReferenceFlow.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":                flow.ObjectMeta.Name,
+				"app.kubernetes.io/managed-by":          "rancher-logging-explorer",
+				"app.kubernetes.io/created-by":          "logging-plumber",
+				"loggingplumber.isala.me/flowtest-uuid": string(flowTest.ObjectMeta.UID),
+				"loggingplumber.isala.me/flowtest":      flowTest.ObjectMeta.Name,
+			},
+		},
+		Spec: flowv1beta1.ClusterFlowSpec{
+			GlobalOutputRefs: nil,
+			Match: []flowv1beta1.ClusterMatch{{
+				ClusterSelect: &flowv1beta1.ClusterSelect{Labels: extraLabels},
+			}},
+		},
+	}
+
+	outTemplate := flowv1beta1.ClusterOutput{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "logging.banzaicloud.io/v1beta1",
+			Kind:       "ClusterOutput",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-test", flow.ObjectMeta.Name),
+			Namespace: flowTest.Spec.ReferenceFlow.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":                flow.ObjectMeta.Name,
+				"app.kubernetes.io/managed-by":          "rancher-logging-explorer",
+				"app.kubernetes.io/created-by":          "logging-plumber",
+				"loggingplumber.isala.me/flowtest-uuid": string(flowTest.ObjectMeta.UID),
+				"loggingplumber.isala.me/flowtest":      flowTest.ObjectMeta.Name,
+			},
+		},
+		Spec: flowv1beta1.ClusterOutputSpec{
+			OutputSpec: flowv1beta1.OutputSpec{
+				HTTPOutput: &output.HTTPOutputConfig{
+					Endpoint: "http://logging-plumber-log-aggregator.default.svc",
+					Buffer: &output.Buffer{
+						FlushMode:     "interval",
+						FlushInterval: "10s",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Added necessary code to test `ClusterFlows`

![image](https://user-images.githubusercontent.com/29277992/125484779-f7a80389-3ecb-4942-aaba-8db1d58c6589.png)

Limitations:
- Failed matches on ClusterFlows are recorded separately under `failedClusterMatches`.
    - This is due [ClusterFlowSpec](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/crds/v1beta1/clusterflow_types/#clusterflowspec) uses [ClusterMatch](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/crds/v1beta1/clusterflow_types/#clusterflowspec-match) and [FlowSpec](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/crds/v1beta1/flow_types/) using [Match](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/crds/v1beta1/flow_types/#match).
- Lot of code duplication.
- Assume the user has the reference ClusterFlow right namespace. 

Closes: #6 