### PR TITLE
Updated pod-simulator use log-dir as flag

### DIFF
--- a/operator/controllers/provision.go
+++ b/operator/controllers/provision.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	flowv1beta1 "github.com/banzaicloud/logging-operator/pkg/sdk/api/v1beta1"
 	loggingplumberv1alpha1 "github.com/mrsupiri/rancher-logging-explorer/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
@@ -75,7 +76,8 @@ func (r *FlowTestReconciler) provisionResource(ctx context.Context) error {
 				// TODO: Handle more than or less than 1 Container (#12)
 				Name:         referencePod.Spec.Containers[0].Name,
 				Image:        "k3d-rancher-logging-explorer-registry:5000/rancher-logging-explorer/pod-simulator:latest",
-				VolumeMounts: []v1.VolumeMount{{Name: "config-volume", MountPath: "/var/logs"}},
+				Args:         []string{"-log-dir", "/simulation.log"},
+				VolumeMounts: []v1.VolumeMount{{Name: "config-volume", MountPath: "/simulation.log", SubPath: "simulation.log"}},
 			}},
 			Volumes: []v1.Volume{
 				{

--- a/pod-simulator/main.go
+++ b/pod-simulator/main.go
@@ -2,16 +2,23 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 )
 
 func main() {
-	echoDelay := 3 * time.Second
-	if delay, err := strconv.Atoi(os.Getenv("ECHO_DELAY")); err == nil {
-		echoDelay = time.Duration(delay) * time.Second
+	var logDir string
+	var echoDelay time.Duration
+	flag.DurationVar(&echoDelay, "delay", 3*time.Second, "interval between 2 log echos")
+	flag.StringVar(&logDir, "log-dir", "", "absolute path for the log file")
+	flag.Parse()
+
+	if len(logDir) == 0 {
+		fmt.Println("Usage: ./pod-simulator -log-dir")
+		flag.PrintDefaults()
+		os.Exit(1)
 	}
 
 	// Source - https://www.geeksforgeeks.org/how-to-read-a-file-line-by-line-to-string-in-golang/
@@ -19,11 +26,10 @@ func main() {
 	// os.Open() opens specific file in
 	// read-only mode and this return
 	// a pointer of type os.
-	file, err := os.Open("/var/logs/simulation.log")
+	file, err := os.Open(logDir)
 
 	if err != nil {
-		panic("failed to open simulation.log")
-
+		panic(fmt.Sprintf("failed to %s", logDir))
 	}
 
 	// The bufio.NewScanner() function is called in which the


### PR DESCRIPTION
Now pod simulator requires `log-dir` as the required flag to run. 
I also moved the delay from an environment variable to a flag with the default of 3 seconds.

![image](https://user-images.githubusercontent.com/29277992/126042275-cbb46a26-5acd-41a8-9965-92a6f9c3dabc.png)

Issue: #15 