### PR TITLE
Added endpoint to proxy the kube api

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -20,8 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-#FROM gcr.io/distroless/static:nonroot
-FROM alpine
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -13,13 +13,15 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY internal/ internal/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+#FROM gcr.io/distroless/static:nonroot
+FROM alpine
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -67,7 +67,8 @@ docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	docker tag ${IMG} localhost:37129/${IMG}
+	docker push localhost:37129/${IMG}
 
 ##@ Deployment
 
@@ -78,7 +79,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image controller=k3d-rancher-logging-explorer-registry:5000/${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: k3d-rancher-logging-explorer-registry:5000/controller
   newTag: latest

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -25,9 +25,6 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-        - args: ["proxy", "--port=8231"]
-          image: bitnami/kubectl:latest
-          name: kubectl-proxy
         - command:
             - /manager
           args:

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -25,32 +25,35 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - command:
-        - /manager
-        args:
-        - --leader-elect
-        image: controller:latest
-        name: manager
-        securityContext:
-          allowPrivilegeEscalation: false
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
+        - args: ["proxy", "--port=8231"]
+          image: bitnami/kubectl:latest
+          name: kubectl-proxy
+        - command:
+            - /manager
+          args:
+            - --leader-elect
+          image: controller:latest
+          name: manager
+          securityContext:
+            allowPrivilegeEscalation: false
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 100m
+              memory: 30Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/operator/internal/server/handlers.go
+++ b/operator/internal/server/handlers.go
@@ -1,25 +1,22 @@
 package server
 
 import (
-	"context"
-	"encoding/json"
+	"embed"
 	"fmt"
-	"github.com/mrsupiri/rancher-logging-explorer/internal/server/manifests"
+	"io/fs"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strings"
 )
 
-func (ws *WebServer) WriteResponse(w http.ResponseWriter, httpRes HTTPResponse) {
-	res, jsErr := json.Marshal(httpRes)
-	if jsErr != nil {
-		ws.logger.Error(jsErr, "failed jsonify HTTPResponse")
-	}
-	_, err := w.Write(res)
-	if err != nil {
-		ws.logger.Error(err, "failed to write to ResponseWriter")
-	}
+//go:embed build
+var content embed.FS
+
+func clientHandler() http.Handler {
+	fsys := fs.FS(content)
+	contentStatic, _ := fs.Sub(fsys, "build")
+	return http.FileServer(http.FS(contentStatic))
 }
 
 func (ws *WebServer) ProxyToKubeAPI(res http.ResponseWriter, req *http.Request) {
@@ -32,70 +29,4 @@ func (ws *WebServer) ProxyToKubeAPI(res http.ResponseWriter, req *http.Request) 
 
 	ws.logger.V(1).Info(fmt.Sprintf("proxying %s to %s", req.URL, targetUrl))
 	proxy.ServeHTTP(res, req)
-}
-
-func (ws *WebServer) DeployLogOutput(w http.ResponseWriter, _ *http.Request) {
-	var err error
-	ws.logger.V(1).Info("Deploying the log-output")
-	w.Header().Set("Content-Type", "application/json")
-
-	d, s, err := manifests.GetLogOutput()
-	if err != nil {
-		ws.logger.Error(err, "failed fetch log-output manifests")
-		w.WriteHeader(500)
-		ws.WriteResponse(w, HTTPResponse{Error: &HTTPError{Error: err.Error(), Message: "failed fetch log-output manifests"}})
-		return
-	}
-
-	err = ws.kubeClient.Create(context.TODO(), &d)
-	if err != nil {
-		ws.logger.Error(err, "failed to create log-output deployment")
-		w.WriteHeader(500)
-		ws.WriteResponse(w, HTTPResponse{Error: &HTTPError{Error: err.Error(), Message: "failed to create log-output deployment"}})
-		return
-	}
-
-	err = ws.kubeClient.Create(context.TODO(), &s)
-	if err != nil {
-		ws.logger.Error(err, "failed to create log-output service")
-		w.WriteHeader(500)
-		ws.WriteResponse(w, HTTPResponse{Error: &HTTPError{Error: err.Error(), Message: "failed to create log-output service"}})
-		return
-	}
-
-	w.WriteHeader(200)
-	ws.WriteResponse(w, HTTPResponse{Data: &HTTPData{Message: "log-output deployed successfully"}})
-}
-func (ws *WebServer) DestroyLogOutput(w http.ResponseWriter, r *http.Request) {
-	var err error
-	ws.logger.V(1).Info("Destroying the log-output")
-	w.Header().Set("Content-Type", "application/json")
-
-	d, s, err := manifests.GetLogOutput()
-	if err != nil {
-		ws.logger.Error(err, "failed fetch log-output manifests")
-		w.WriteHeader(500)
-		w.WriteHeader(500)
-		ws.WriteResponse(w, HTTPResponse{Error: &HTTPError{Error: err.Error(), Message: "failed fetch log-output manifests"}})
-		return
-	}
-
-	err = ws.kubeClient.Delete(context.TODO(), &d)
-	if err != nil {
-		ws.logger.Error(err, "failed to destroy log-output deployment")
-		w.WriteHeader(500)
-		ws.WriteResponse(w, HTTPResponse{Error: &HTTPError{Error: err.Error(), Message: "failed to destroy log-output service"}})
-		return
-	}
-
-	err = ws.kubeClient.Delete(context.TODO(), &s)
-	if err != nil {
-		ws.logger.Error(err, "failed to destroy log-output service")
-		w.WriteHeader(500)
-		ws.WriteResponse(w, HTTPResponse{Error: &HTTPError{Error: err.Error(), Message: "failed to destroy log-output service"}})
-		return
-	}
-
-	w.WriteHeader(200)
-	ws.WriteResponse(w, HTTPResponse{Data: &HTTPData{Message: "log-output destroyed successfully"}})
 }

--- a/operator/internal/server/server.go
+++ b/operator/internal/server/server.go
@@ -1,11 +1,15 @@
 package server
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"embed"
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"io/fs"
+	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -16,15 +20,59 @@ type WebServer struct {
 	kubeClient client.Client
 	port       string
 	logger     logr.Logger
+	kubeProxy  KubeProxy
 }
+type KubeProxy struct {
+	endpoint       string
+	token          string
+	proxyTransport *http.Transport
+}
+
+const (
+	tokenFile  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+)
 
 // NewWebServer returns an HTTP server that handles webhooks
 func NewWebServer(port string, kubeClient client.Client) *WebServer {
 	logger := ctrl.Log.WithName("web-server")
+
+	// Setup proxy data
+	token, err := ioutil.ReadFile(tokenFile)
+	if err != nil {
+		logger.V(3).Info("failed to read the token from kubernetes secrets")
+	}
+	CAData, err := ioutil.ReadFile(rootCAFile)
+	if err != nil {
+		logger.V(3).Info("failed to read the CA Data from kubernetes secrets")
+	}
+
+	// Get the SystemCertPool, continue with an empty pool on error
+	rootCAs, _ := x509.SystemCertPool()
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+
+	// Append our cert to the system pool
+	if ok := rootCAs.AppendCertsFromPEM(CAData); !ok {
+		logger.V(3).Info("failed to append k8s custom CA, using system certs only")
+	}
+
+	if err != nil {
+		logger.V(3).Info("it seems like operator is not running in side cluster, kube-api proxy will not operate as intended")
+	}
+
 	return &WebServer{
 		kubeClient: kubeClient,
 		port:       port,
 		logger:     logger,
+		kubeProxy: KubeProxy{
+			endpoint: "https://" + net.JoinHostPort(os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")),
+			token:    string(token),
+			proxyTransport: &http.Transport{TLSClientConfig: &tls.Config{
+				RootCAs: rootCAs,
+			}},
+		},
 	}
 }
 

--- a/operator/internal/server/server.go
+++ b/operator/internal/server/server.go
@@ -42,6 +42,7 @@ func (ws *WebServer) ListenAndServe(stopCh <-chan struct{}) {
 
 	r.HandleFunc("/log-output/deploy", ws.DeployLogOutput).Methods("POST")
 	r.HandleFunc("/log-output/destroy", ws.DestroyLogOutput).Methods("POST")
+	r.PathPrefix("/k8s").HandlerFunc(ws.ProxyToKubeAPI)
 	r.PathPrefix("/").Handler(clientHandler())
 
 	go func() {

--- a/operator/main.go
+++ b/operator/main.go
@@ -95,7 +95,7 @@ func main() {
 	//+kubebuilder:scaffold:builder
 	setupLog.Info("starting web server", "addr", webAddr)
 	ctx := ctrl.SetupSignalHandler()
-	webServer := server.NewWebServer(webAddr, mgr.GetClient())
+	webServer := server.NewWebServer(webAddr)
 	go webServer.ListenAndServe(ctx.Done())
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
There is a custom web server running in port 9090, with this PR I have created an endpoint on `http://operator:9090/k8s/` which will forward all the traffic coming to it to a  kubectl proxy at port 8231 after dropping `/k8s` from the request URL and which itself will forward the request to kube-api after inserting the bearer token taken from the operators' service account.